### PR TITLE
Setup ci

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - pyiron_workflow

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -27,7 +27,7 @@ jobs:
           no-build-isolation: 'false'
       - name: Add jupyter
         shell: bash -l {0}
-        run: mamba install -n my-env jupyter
+        run: mamba install -n my-env papermill
       - name: Execute workflow
         shell: bash -l {0}
-        run: jupyter nbconvert --ExecutePreprocessor.kernel_name=python3 --execute --to notebook workflow.ipynb
+        run: papermill workflow.ipynb workflow-out.ipynb

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -31,3 +31,8 @@ jobs:
       - name: Execute workflow
         shell: bash -l {0}
         run: papermill workflow.ipynb workflow-out.ipynb -k python3
+      - name: Upload updated notebook as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-out.ipynb
+          path: ./workflow-out.ipynb

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-notebooks@actions-3.1.0
+      - uses: pyiron/actions/build-notebooks@actions-3.2.0
         with:
           python-version: '3.11'
-          env-files: .ci_support/environment.yml
+          env-files: environment.yml

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: '3.11'
           env-files: .ci_support/environment.yml
+          local-code-directory: ''
           use-cache: 'true'
           miniforge-channels: conda-forge
           pip-install-versioneer: 'false'

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -8,14 +8,22 @@ on:
   workflow_call:
 
 jobs:
-  build:
+  run_workflow:
     if: |
       github.event_name == 'push' ||
       ( github.event_name == 'pull_request'  && contains(github.event.pull_request.labels.*.name, 'run_workflow' ))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pyiron/actions/build-notebooks@actions-3.2.0
+      - name: Setup environment
+        uses: pyiron/actions/cached-miniforge@actions-3.2.0
         with:
           python-version: '3.11'
           env-files: .ci_support/environment.yml
+          use-cache: 'true'
+          miniforge-channels: conda-forge
+          pip-install-versioneer: 'false'
+          no-build-isolation: 'false'
+      - name: Execute notebook
+        shell: bash -l {0}
+        run: jupyter nbconvert --execute --to notebook workflow.ipynb

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: pyiron/actions/build-notebooks@actions-3.1.0
         with:
           python-version: '3.11'
-          env-files: ./environment.yml
+          env-files: .ci_support/environment.yml

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -25,9 +25,9 @@ jobs:
           miniforge-channels: conda-forge
           pip-install-versioneer: 'false'
           no-build-isolation: 'false'
-      - name: Add jupyter
+      - name: Add papermill
         shell: bash -l {0}
         run: mamba install -n my-env papermill
       - name: Execute workflow
         shell: bash -l {0}
-        run: papermill workflow.ipynb workflow-out.ipynb
+        run: papermill workflow.ipynb workflow-out.ipynb -k python3

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -1,0 +1,26 @@
+name: Run workflow
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  build:
+    if: |
+      github.event_name == 'push' ||
+      ( github.event_name == 'pull_request'  && contains(github.event.pull_request.labels.*.name, 'run_workflow' ))
+      
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2.2.0
+      with:
+        python-version: "3.11"
+        mamba-version: "*"
+        miniforge-variant: Mambaforge
+        channels: conda-forge
+        channel-priority: strict
+        auto-update-conda: true
+        environment-file: environment.yml

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -5,22 +5,17 @@ on:
     branches: [ main ]
   pull_request:
     types: [labeled, opened, synchronize, reopened]
+  workflow_call:
 
 jobs:
   build:
     if: |
       github.event_name == 'push' ||
       ( github.event_name == 'pull_request'  && contains(github.event.pull_request.labels.*.name, 'run_workflow' ))
-      
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2.2.0
-      with:
-        python-version: "3.11"
-        mamba-version: "*"
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        auto-update-conda: true
-        environment-file: environment.yml
+      - uses: actions/checkout@v4
+      - uses: pyiron/actions/build-notebooks@actions-3.1.0
+        with:
+          python-version: '3.11'
+          env-files: environment.yml

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: pyiron/actions/build-notebooks@actions-3.2.0
         with:
           python-version: '3.11'
-          env-files: environment.yml
+          env-files: .ci_support/environment.yml

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -30,4 +30,4 @@ jobs:
         run: mamba install -n my-env jupyter
       - name: Execute workflow
         shell: bash -l {0}
-        run: jupyter nbconvert --execute --to notebook workflow.ipynb
+        run: jupyter nbconvert --ExecutePreprocessor.kernel_name=python3 --execute --to notebook workflow.ipynb

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
   workflow_call:
-
+    
 jobs:
   run_workflow:
     if: |
@@ -25,6 +25,9 @@ jobs:
           miniforge-channels: conda-forge
           pip-install-versioneer: 'false'
           no-build-isolation: 'false'
-      - name: Execute notebook
+      - name: Add jupyter
+        shell: bash -l {0}
+        run: mamba install -n my-env jupyter
+      - name: Execute workflow
         shell: bash -l {0}
         run: jupyter nbconvert --execute --to notebook workflow.ipynb

--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: pyiron/actions/build-notebooks@actions-3.1.0
         with:
           python-version: '3.11'
-          env-files: environment.yml
+          env-files: ./environment.yml

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # graphathon
 
-Playground for collaborative environment in order to create a workflow in parallel by distributing nodes (i.e. tasks) to different people.
+A template repository for setting up an environment where nodes for a workflow using `pyiron_workflow` can be developed by different people in parallel.
 
-## Basic idea
-
-1. Create a workflow in a large group, with empty nodes with only inputs and outputs defined
-2. Distribute the nodes to different people
-3. As people finish their tasks, they push the nodes to the repository, where CI takes care of the workflow execution
-
-More will follow...
+Usage goes like so:
+- the team sets up a dummy workflow using placeholder-vwersions of the involved nodes
+- the team creates a repository using *this* repo as a template (especially anything located in `.github/` and `.ci_support/`)
+- each dev opens a branch + PR for her work
+- as soon as the `run_workflow` label is added to the PR, each push triggers workflow execution via actions.
+- the updated notebook is uploaded as a github action artifact (Actions -> select CI run -> Artifacts). Download, unzip and view locally.

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,0 @@
-channels:
-  - conda-forge
-dependencies:
-  - pyiron_workflow

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - pyiron_workflow

--- a/nodes/time.py
+++ b/nodes/time.py
@@ -2,4 +2,4 @@ from pyiron_workflow import Workflow
 
 @Workflow.wrap.as_function_node("travel_time")
 def get_time(distance: float, speed: float) -> float:
-    return 10.
+    return 42.


### PR DESCRIPTION
Here, I setup the CI for the automatic (headless) execution of the workflow. (heads up: with "workflow" I'll reefer to the actual pyiron workflow. When I'm talking about a github workflow, I'll call it "gh-workflow".)

The idea is like so:
A team wants to collaborate on a workflow using `pyiron_workflow`. Some devs are now working **individually** on the required nodes. As soon as there is a (maybe dummy) workflow existent, the team can open a repository following this repo as a template and include their nodes (by copying them to `./nodes/`). Now the create a branch to work on, and all devs are committing their work. When the label "run_workflow" is added, each commit then triggers a headless execution of the related `./workflow.ipynb` using `jupyter nbconvert`. The changes made to the notebook `workflow.ipynb` (e.g. printed results, shown figures, the drawn workflow, ...) are written to a notebook called `workflow-out.ipynb`. This is then uploaded as an artifact and can be viewed looking at the respective actions run. This way, a dev can see the changes caused by her commit in a rendered form.

In a first draft, I hard-coded some stuff that could be left to a user to be defined (e.g. the name of the conda environment or the name of the workflowfile/notebook). However, once the repository's CI works as intended, we should merge this PR. I will then improve the whole usage in another PR.